### PR TITLE
feat(search): create search route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tv_prog_rust_api"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tv_prog_rust_api"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2024"
 
 [dependencies]

--- a/src/data/repositories/program_repository.rs
+++ b/src/data/repositories/program_repository.rs
@@ -16,3 +16,7 @@ pub(crate) fn get_current_program_by_channel_id(channel_id: String) -> Program {
 pub(crate) fn get_tonight_program_by_channel_id(channel_id: String) -> Program {
     postgres_client::find_tonight_program_by_channel_id(channel_id)
 }
+
+pub(crate) fn search_programs(query: String) -> Vec<Program> {
+    postgres_client::search_programs(query)
+}

--- a/src/data/repositories/xml_tv_repository.rs
+++ b/src/data/repositories/xml_tv_repository.rs
@@ -68,7 +68,7 @@ pub async fn init_xml_tv_data() {
                 program_converter::model_to_entity(p)
             })
             .collect::<Vec<Program>>();
-        if(unknown_fr_programs.len()>0) {
+        if unknown_fr_programs.len()>0 {
             println!("Found {} unknown FR channels", unknown_fr_programs.len());
             postgres_client::bulk_insert_programs(unknown_fr_programs);
         } else {

--- a/src/data/sources/api/xmltv_client.rs
+++ b/src/data/sources/api/xmltv_client.rs
@@ -6,7 +6,7 @@ use zip::ZipArchive;
 pub fn base_url() -> String {
     let base_url =
         var("XMLTV_BASE_URL").expect("XMLTV_BASE_URL must be set in the environment variables");
-    if (base_url.ends_with("/")) {
+    if base_url.ends_with("/") {
         return base_url;
     }
     return base_url + "/";

--- a/src/data/sources/db/postgres_client.rs
+++ b/src/data/sources/db/postgres_client.rs
@@ -211,3 +211,24 @@ pub(crate) fn find_tonight_program_by_channel_id(channel_id: String) -> Program 
     .join()
     .unwrap()
 }
+
+pub(crate) fn search_programs(query_string: String) -> Vec<Program> {
+    std::thread::spawn(move || {
+        let mut programs = Vec::new();
+        let mut client = client();
+        let query = format!("%{}%", query_string);
+        let rows = client
+            .query(
+                "SELECT * FROM PROGRAMS WHERE TITLE ILIKE $1 OR SUBTITLE ILIKE $1 OR DESCRIPTION ILIKE $1",
+                &[&query],
+            )
+            .unwrap();
+        for row in rows {
+            let program = program_converter::row_to_entity(&row);
+            programs.push(program);
+        }
+        programs
+    })
+    .join()
+    .unwrap()
+}

--- a/src/presentation/handlers/programs_handler.rs
+++ b/src/presentation/handlers/programs_handler.rs
@@ -32,3 +32,11 @@ pub async fn get_tonight_program_by_channel_id(Query(params): Query<HashMap<Stri
     let program = program_repository::get_tonight_program_by_channel_id(channel_id);
     Json(Some(program))
 }
+
+pub async fn search_programs(Json(payload): Json<HashMap<String, String>>) -> Json<Vec<Program>> {
+    let query = match payload.get("query") {
+        Some(q) => q.clone(),
+        None => return Json(vec![]),
+    };
+    Json(program_repository::search_programs(query))
+}

--- a/src/presentation/routes/router.rs
+++ b/src/presentation/routes/router.rs
@@ -1,5 +1,9 @@
 use crate::presentation::handlers::channels_handler::get_channels_by_package;
-use crate::presentation::handlers::programs_handler::{get_current_program_by_channel_id, get_programs_by_channel_id, get_tonight_program_by_channel_id};
+use crate::presentation::handlers::programs_handler::{
+    get_current_program_by_channel_id, get_programs_by_channel_id,
+    get_tonight_program_by_channel_id, search_programs,
+};
+use axum::routing::post;
 use axum::{Router, routing::get};
 
 pub fn create_router() -> Router {
@@ -8,5 +12,6 @@ pub fn create_router() -> Router {
         .route("/programs", get(get_programs_by_channel_id))
         .route("/programs/current", get(get_current_program_by_channel_id))
         .route("/programs/tonight", get(get_tonight_program_by_channel_id))
+        .route("/programs/search", post(search_programs))
         .fallback(get(|| async { "Not Found" }))
 }


### PR DESCRIPTION
This pull request introduces a new search feature for TV programs and includes minor code style improvements. The most significant changes are the addition of a search endpoint for programs, the implementation of the underlying database query, and some code cleanup for consistency.

### New search functionality

* Added a new `search_programs` endpoint to the API (`/programs/search`) that allows users to search for programs by title, subtitle, or description using a POST request. [[1]](diffhunk://#diff-9a322ed734e514e21807b759cb881838632330315d0d29147fcf24f0b1b595d9L2-R6) [[2]](diffhunk://#diff-9a322ed734e514e21807b759cb881838632330315d0d29147fcf24f0b1b595d9R15) [[3]](diffhunk://#diff-85fbe436bdab85fe9e0557bf31440024d79cb5edd88b467b18eadc3b0bf0a8d7R35-R42)
* Implemented the `search_programs` function in the `program_repository` and the corresponding database query in `postgres_client`, enabling case-insensitive search across multiple fields. [[1]](diffhunk://#diff-f63dc83707e8a1e1f331b61784737297ba3c58f34d602aaf3732f801de22ec6bR19-R22) [[2]](diffhunk://#diff-07ec09876f7a22ee3ac42b9ab44634b457f699c8ea20077e021eca0ac9f677b1R214-R234)

### Code style and consistency improvements

* Fixed formatting and style in conditional expressions for better Rust idiomatic code in `xml_tv_repository.rs` and `xmltv_client.rs`. [[1]](diffhunk://#diff-9a297e60a2c2bfbaa59f1450a81851ebff5defdd9b670e8575ec09d7a9abceb2L71-R71) [[2]](diffhunk://#diff-235530a434a1851d8388c1a85aff312722a76eae23e73d4bdfb36df936f70ffeL9-R9)

### Versioning

* Bumped the crate version to `1.1.0` in `Cargo.toml` to reflect the addition of new features.